### PR TITLE
redis not upgradeable

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,8 +141,8 @@
 #
 class redis (
   $version = $redis::params::version,
-  $redis_src_dir = $redis::params::redis_src_dir,
-  $redis_bin_dir = $redis::params::redis_bin_dir,
+  $redis_src_dir = "${redis::params::redis_src_dir}-${version}",
+  $redis_bin_dir = "${redis::params::redis_bin_dir}-${version}",
   $redis_user = $redis::params::redis_user,
   $redis_group = $redis::params::redis_group,
   $redis_port = $redis::params::redis_port,


### PR DESCRIPTION
Installing any redis version works fine.

However when I try to upgrade (in my case to 3.0.4) the installation fails (it still remains the old version and cannot read the new config file). This happens due to the fact that the source and the bin folder are not replaced with the new contents.

My fix is just to create a folder for every version and install it from there.